### PR TITLE
Feature: Add Request macros (isCrawler & crawler) for fluent detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,28 @@ public function index(CrawlerDetect $crawlerDetect)
 }
 ```
 
+### Using the Request macros
+
+```php
+use Illuminate\Http\Request;
+
+public function index(Request $request)
+{
+    // Check if the current request is a crawler
+    if ($request->isCrawler()) {
+        // dd($request->crawler()->getMatches())
+    }
+    
+    // You can also pass a specific user agent to test
+    $isCrawler = $request->isCrawler('Mozilla/5.0 (compatible; Googlebot/2.1; +[http://www.google.com/bot.html](http://www.google.com/bot.html))');
+    
+    // If you need the crawler name, you can get the CrawlerDetect instance
+    if ($request->isCrawler()) {
+        echo $request->crawler()->getMatches();
+    }
+}
+```
+
 ## Testing
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -54,24 +54,21 @@ public function index(CrawlerDetect $crawlerDetect)
 }
 ```
 
-### Using the Request macros
+Or use the `Request` macros, which detect using the current request:
 
 ```php
 use Illuminate\Http\Request;
 
 public function index(Request $request)
 {
-    // Check if the current request is a crawler
     if ($request->isCrawler()) {
-        // dd($request->crawler()->getMatches())
-    }
-    
-    // You can also pass a specific user agent to test
-    $isCrawler = $request->isCrawler('Mozilla/5.0 (compatible; Googlebot/2.1; +[http://www.google.com/bot.html](http://www.google.com/bot.html))');
-    
-    // If you need the crawler name, you can get the CrawlerDetect instance
-    if ($request->isCrawler()) {
+        // Output the name of the bot that matched (if any)
         echo $request->crawler()->getMatches();
+    }
+
+    // Or pass a user agent string to check
+    if ($request->isCrawler('Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)')) {
+        // ...
     }
 }
 ```

--- a/_ide_macros.php
+++ b/_ide_macros.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Http {
 
     /**
-     * @method \Jaybizzle\CrawlerDetect\CrawlerDetect crawler(?array $headers = null, ?string $userAgent = null)
+     * @method \Jaybizzle\CrawlerDetect\CrawlerDetect crawler()
      * @method bool isCrawler(?string $userAgent = null)
      */
     class Request

--- a/_ide_macros.php
+++ b/_ide_macros.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Illuminate\Http {
+    /**
+     * @method \Jaybizzle\CrawlerDetect\CrawlerDetect crawler(?array $headers = null, ?string $userAgent = null)
+     * @method bool isCrawler(?string $userAgent = null)
+     */
+    class Request
+    {
+
+    }
+}

--- a/_ide_macros.php
+++ b/_ide_macros.php
@@ -1,12 +1,13 @@
 <?php
 
 namespace Illuminate\Http {
+
     /**
      * @method \Jaybizzle\CrawlerDetect\CrawlerDetect crawler(?array $headers = null, ?string $userAgent = null)
      * @method bool isCrawler(?string $userAgent = null)
      */
     class Request
     {
-
+        //
     }
 }

--- a/src/LaravelCrawlerDetectServiceProvider.php
+++ b/src/LaravelCrawlerDetectServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace Jaybizzle\LaravelCrawlerDetect;
 
+use Illuminate\Foundation\Application;
+use Illuminate\Http\Request;
 use Illuminate\Support\ServiceProvider;
 use Jaybizzle\CrawlerDetect\CrawlerDetect;
 
@@ -14,10 +16,32 @@ class LaravelCrawlerDetectServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton(CrawlerDetect::class, function ($app) {
-            return new CrawlerDetect($app['request']->server());
+        $this->app->singleton(CrawlerDetect::class, function (Application $app, array $parameters = []) {
+            $headers = $parameters['headers'] ?? $app['request']->server();
+            $userAgent = $parameters['userAgent'] ?? null;
+
+            return new CrawlerDetect($headers, $userAgent);
         });
 
         $this->app->alias(CrawlerDetect::class, 'LaravelCrawlerDetect');
+    }
+
+    /**
+     * Bootstrap the application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        Request::macro('crawler', function (?array $headers = null, ?string $userAgent = null) {
+            return app(CrawlerDetect::class, [
+                'headers' => $headers,
+                'userAgent' => $userAgent,
+            ]);
+        });
+
+        Request::macro('isCrawler', function (?string $userAgent = null) {
+            return $this->crawler(userAgent: $userAgent)->isCrawler();
+        });
     }
 }

--- a/src/LaravelCrawlerDetectServiceProvider.php
+++ b/src/LaravelCrawlerDetectServiceProvider.php
@@ -16,11 +16,8 @@ class LaravelCrawlerDetectServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton(CrawlerDetect::class, function (Application $app, array $parameters = []) {
-            $headers = $parameters['headers'] ?? $app['request']->server();
-            $userAgent = $parameters['userAgent'] ?? null;
-
-            return new CrawlerDetect($headers, $userAgent);
+        $this->app->singleton(CrawlerDetect::class, function (Application $app) {
+            return new CrawlerDetect($app['request']->server());
         });
 
         $this->app->alias(CrawlerDetect::class, 'LaravelCrawlerDetect');
@@ -33,15 +30,17 @@ class LaravelCrawlerDetectServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        Request::macro('crawler', function (?array $headers = null, ?string $userAgent = null) {
-            return app(CrawlerDetect::class, [
-                'headers' => $headers,
-                'userAgent' => $userAgent,
-            ]);
+        Request::macro('crawler', function (?string $userAgent = null) {
+            $crawler = app(CrawlerDetect::class);
+
+            $crawler->setHttpHeaders($this->server->all());
+            $crawler->setUserAgent($userAgent ?? $this->userAgent());
+
+            return $crawler;
         });
 
         Request::macro('isCrawler', function (?string $userAgent = null) {
-            return $this->crawler(userAgent: $userAgent)->isCrawler();
+            return $this->crawler($userAgent)->isCrawler();
         });
     }
 }

--- a/src/LaravelCrawlerDetectServiceProvider.php
+++ b/src/LaravelCrawlerDetectServiceProvider.php
@@ -30,17 +30,19 @@ class LaravelCrawlerDetectServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        Request::macro('crawler', function (?string $userAgent = null) {
-            $crawler = app(CrawlerDetect::class);
+        Request::macro('crawler', function () {
+            // Scoped to the request rather than resolved from the container, so
+            // that mutating it can't leak into the shared singleton, and so two
+            // requests in the same lifecycle can't overwrite each other.
+            if (! $this->attributes->has('jaybizzle.crawler-detect')) {
+                $this->attributes->set('jaybizzle.crawler-detect', new CrawlerDetect($this->server->all()));
+            }
 
-            $crawler->setHttpHeaders($this->server->all());
-            $crawler->setUserAgent($userAgent ?? $this->userAgent());
-
-            return $crawler;
+            return $this->attributes->get('jaybizzle.crawler-detect');
         });
 
         Request::macro('isCrawler', function (?string $userAgent = null) {
-            return $this->crawler($userAgent)->isCrawler();
+            return $this->crawler()->isCrawler($userAgent);
         });
     }
 }

--- a/tests/UATest.php
+++ b/tests/UATest.php
@@ -10,6 +10,8 @@ use Orchestra\Testbench\TestCase;
 
 class UATest extends TestCase
 {
+    const CRAWLER_USER_AGENT = 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)';
+
     protected function getPackageProviders($app)
     {
         return [LaravelCrawlerDetectServiceProvider::class];
@@ -72,9 +74,59 @@ class UATest extends TestCase
     public function test_request_macro_preserves_matches_state()
     {
         $request = Request::create('/', 'GET');
-        $this->assertTrue($request->isCrawler('Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'));
+        $this->assertTrue($request->isCrawler(self::CRAWLER_USER_AGENT));
         $this->assertNotNull($request->crawler()->getMatches());
         $this->assertSame('Googlebot', $request->crawler()->getMatches());
+    }
+
+    public function test_request_macro_does_not_mutate_the_shared_instance()
+    {
+        $request = $this->humanRequest();
+        $this->app->instance('request', $request);
+
+        $shared = $this->app->make(CrawlerDetect::class);
+        $this->assertFalse($shared->isCrawler());
+
+        $request->isCrawler(self::CRAWLER_USER_AGENT);
+
+        $this->assertFalse($shared->isCrawler());
+        $this->assertFalse(Crawler::isCrawler());
+        $this->assertNotSame($shared, $request->crawler());
+    }
+
+    public function test_request_macro_instances_are_scoped_to_the_request()
+    {
+        $crawler = Request::create('/', 'GET', [], [], [], [
+            'HTTP_USER_AGENT' => self::CRAWLER_USER_AGENT,
+        ]);
+        $human = $this->humanRequest();
+
+        $this->assertSame($crawler->crawler(), $crawler->crawler());
+        $this->assertNotSame($crawler->crawler(), $human->crawler());
+
+        $this->assertTrue($crawler->isCrawler());
+        $this->assertFalse($human->isCrawler());
+        $this->assertTrue($crawler->isCrawler());
+    }
+
+    public function test_request_macro_user_agent_override_does_not_persist()
+    {
+        $request = $this->humanRequest();
+
+        $this->assertTrue($request->isCrawler(self::CRAWLER_USER_AGENT));
+        $this->assertFalse($request->isCrawler());
+    }
+
+    /**
+     * A request from a browser rather than a crawler.
+     *
+     * @return Request
+     */
+    protected function humanRequest()
+    {
+        return Request::create('/', 'GET', [], [], [], [
+            'HTTP_USER_AGENT' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
+        ]);
     }
 
     /**

--- a/tests/UATest.php
+++ b/tests/UATest.php
@@ -60,6 +60,10 @@ class UATest extends TestCase
 
         $this->assertFalse($request->isCrawler());
 
+        foreach ($this->fixture('devices.txt') as $userAgent) {
+            $this->assertFalse($request->isCrawler($userAgent));
+        }
+
         foreach ($this->fixture('crawlers.txt') as $userAgent) {
             $this->assertTrue($request->isCrawler($userAgent));
         }

--- a/tests/UATest.php
+++ b/tests/UATest.php
@@ -2,6 +2,7 @@
 
 namespace Jaybizzle\LaravelCrawlerDetect\Tests;
 
+use Illuminate\Http\Request;
 use Jaybizzle\CrawlerDetect\CrawlerDetect;
 use Jaybizzle\LaravelCrawlerDetect\Facades\LaravelCrawlerDetect as Crawler;
 use Jaybizzle\LaravelCrawlerDetect\LaravelCrawlerDetectServiceProvider;
@@ -39,6 +40,37 @@ class UATest extends TestCase
         foreach ($this->fixture('devices.txt') as $userAgent) {
             $this->assertFalse(Crawler::isCrawler($userAgent), $userAgent);
         }
+    }
+
+    public function test_request_macro_detects_crawler_from_request_headers()
+    {
+        foreach ($this->fixture('crawlers.txt') as $userAgent) {
+            $request = Request::create('/', 'GET', [], [], [], [
+                'HTTP_USER_AGENT' => $userAgent,
+            ]);
+            $this->assertTrue($request->isCrawler());
+        }
+    }
+
+    public function test_request_macro_can_override_user_agent()
+    {
+        $request = Request::create('/', 'GET', [], [], [], [
+            'HTTP_USER_AGENT' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
+        ]);
+
+        $this->assertFalse($request->isCrawler());
+
+        foreach ($this->fixture('crawlers.txt') as $userAgent) {
+            $this->assertTrue($request->isCrawler($userAgent));
+        }
+    }
+
+    public function test_request_macro_preserves_matches_state()
+    {
+        $request = Request::create('/', 'GET');
+        $this->assertTrue($request->isCrawler('Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'));
+        $this->assertNotNull($request->crawler()->getMatches());
+        $this->assertSame('Googlebot', $request->crawler()->getMatches());
     }
 
     /**


### PR DESCRIPTION
This PR introduces two convenient macros to Laravel's `Illuminate\Http\Request` instance: `isCrawler()` and `crawler()`.

This provides a more fluent, "Laravel-like" DX when working inside controllers or middleware, allowing developers to check for crawlers directly from the current request without needing to import the `Crawler` facade.

### Changes Included

1. **Request Macros:** Registered `Request::macro('crawler')` and `Request::macro('isCrawler')` in the `boot` method of `LaravelCrawlerDetectServiceProvider`.
2. **Request Context:** The macros automatically use the headers and user agent from the current `$request` instance (`$this`), ensuring accurate detection even if the request is faked or modified during testing.
3. **IDE Support:** Added a lightweight `_ide_macros.php` stub. This file is excluded from Composer's autoload but is automatically indexed by IDEs, providing out-of-the-box autocompletion.
4. **Documentation:** Updated `README.md` to include usage examples.

### Usage Example

```php
public function index(Request $request)
{
    if ($request->isCrawler()) {
        $botName = $request->crawler()->getMatches();
        // ...
    }
}